### PR TITLE
Fix: using ref the right way

### DIFF
--- a/metadata/plugin_metadata_generator.py
+++ b/metadata/plugin_metadata_generator.py
@@ -34,7 +34,7 @@ class PluginMetadataGenerator:
         return (
             self.latest_prerelease
             or self.latest_stable
-            or self.repo_metadata.get("default_branch")
+            or self.repo_metadata.default_branch
         )
 
     async def fetch_repository_info(self, github: GitHubAPI) -> bool:
@@ -126,10 +126,11 @@ class PluginMetadataGenerator:
         manifest_path = f"custom_plugins/{self.domain}/manifest.json"
         try:
             response = await github.repos.contents.get(
-                self.repo, manifest_path, ref=self.used_ref
+                self.repo, f"{manifest_path}?ref={self.used_ref}"
             )
             content = base64.b64decode(response.data.content).decode("utf-8")
             self.manifest_data = json.loads(content)
+
             LOGGER.info(
                 f"<{self.repo}> Successfully fetched manifest.json "
                 f"from '{self.used_ref}' branch"
@@ -143,7 +144,7 @@ class PluginMetadataGenerator:
             return True
 
     async def validate_plugin_repository(self, github: GitHubAPI) -> bool:
-        """Fetch the plugin domain and validate the repository structure.
+        """Fetch the plugin domain folder and validate the repository structure.
 
         Args:
         ----
@@ -157,7 +158,7 @@ class PluginMetadataGenerator:
         try:
             LOGGER.info(f"<{self.repo}> Fetching plugin domain")
             response = await github.repos.contents.get(
-                self.repo, etag=self.etag_repository, ref=self.used_ref
+                self.repo, f"?ref={self.used_ref}"
             )
 
             # Check for `custom_plugins/` folder
@@ -175,7 +176,7 @@ class PluginMetadataGenerator:
 
             # Fetch the contens of the `custom_plugins/` folder
             folder_response = await github.repos.contents.get(
-                self.repo, "custom_plugins"
+                self.repo, f"custom_plugins?ref={self.used_ref}"
             )
             subfolders = [item for item in folder_response.data if item.type == "dir"]
 

--- a/tests/test_generate_metadata.py
+++ b/tests/test_generate_metadata.py
@@ -72,16 +72,16 @@ async def test_manifest_domain_mismatch(
     async def wrong_manifest_get(
         repo_name: str,
         path: str = "custom_plugins",
-        ref: str | None = None,
-        etag: str | None = None,
     ) -> MockGitHubResponse:
-        if path == "custom_plugins/testdomain/manifest.json":
+        if not path:
+            path = "custom_plugins"
+        if path.split("?", 1)[0] == "custom_plugins/testdomain/manifest.json":
             content = base64.b64encode(
                 json.dumps(load_fixture("wrong_domain_manifest.json")).encode("utf-8")
             ).decode("utf-8")
             file_data = type("Data", (), {"content": content})
             return MockGitHubResponse(data=file_data, etag="mock_manifest_etag")
-        return await original_get(repo_name, path, ref, etag)
+        return await original_get(repo_name, path)
 
     monkeypatch.setattr(mock_github.repos.contents, "get", wrong_manifest_get)
     plugin = PluginMetadataGenerator("owner/repo")
@@ -106,16 +106,16 @@ async def test_manifest_version_mismatch(
     async def wrong_version_get(
         repo_name: str,
         path: str = "custom_plugins",
-        ref: str | None = None,
-        etag: str | None = None,
     ) -> MockGitHubResponse:
-        if path == "custom_plugins/testdomain/manifest.json":
+        if not path:
+            path = "custom_plugins"
+        if path.split("?", 1)[0] == "custom_plugins/testdomain/manifest.json":
             content = base64.b64encode(
                 json.dumps(load_fixture("wrong_version_manifest.json")).encode("utf-8")
             ).decode("utf-8")
             file_data = type("Data", (), {"content": content})
             return MockGitHubResponse(data=file_data, etag="mock_manifest_etag")
-        return await original_get(repo_name, path, ref, etag)
+        return await original_get(repo_name, path)
 
     monkeypatch.setattr(mock_github.repos.contents, "get", wrong_version_get)
     plugin = PluginMetadataGenerator("owner/repo")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->
## Description

This fixes the issue where the correct ref was not being used when fetching things from github's REST API.

## Checklist
<!--
    Put an `x` in the boxes that you have completed. You can
    also fill these out after creating the PR. If you're unsure
    about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I've added the [RHFest action](https://github.com/RotorHazard/rhfest-action) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've created a github release in my repository.
- [ ] I've added all the requested links below.

**Note:** all checks above should be passed before a pull request will be merged.

## Additional information
<!--
    Details are important, and help us processing your PR.
    Please be sure to fill out additional details.
-->

- Link to plugin repository:
- Link to current release:
- Link to successful rhfest action:
