### PR TITLE
Add LED Callsign Image

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -28,6 +28,7 @@
     "i-am-grub/VRxC_ELRS"
   ],
   "LED Effects": [
+    "HazardCreative/RotorHazard-LED-Callsign-Image"
   ],
   "Streaming & Overlays": [
     "dutchdronesquad/rh-youtube-chapters",

--- a/plugins.json
+++ b/plugins.json
@@ -13,6 +13,7 @@
   "HazardCreative/RotorHazard-Class-Rank-Best-Percentage",
   "HazardCreative/RotorHazard-Class-Rank-Best-X-Laps",
   "HazardCreative/RotorHazard-Class-Rank-Heat-Points",
+  "HazardCreative/RotorHazard-LED-Callsign-Image",
   "i-am-grub/MultiGP_Toolkit",
   "i-am-grub/netpack-installer",
   "i-am-grub/VRxC_ELRS",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->
## Description
Pulls PNG images to display on LED panel based on pilot callsign


## Checklist
<!--
  Put an `x` in the boxes that you have completed. You can
  also fill these out after creating the PR. If you're unsure
  about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I've added the [RHFest action](https://github.com/RotorHazard/rhfest-action) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've created a github release in my repository with [semver](https://semver.org/) versioning.
- [x] I've added all the requested links below.

**Note:** all checks above should be passed before a pull request will be merged.

## Additional information
<!--
  Details are important, and help us processing your PR.
  Please be sure to fill out additional details.
-->

- Link to plugin repository: https://github.com/HazardCreative/RotorHazard-LED-Callsign-Image
- Link to current release: https://github.com/HazardCreative/RotorHazard-LED-Callsign-Image/releases/tag/v1.1.0
- Link to successful rhfest action: https://github.com/HazardCreative/RotorHazard-LED-Callsign-Image/actions/runs/15763511689/job/44435215909
