### PR TITLE
Add RaceLink_RH-plugin

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -34,8 +34,7 @@
   ],
   "LED Effects": [
     "HazardCreative/RotorHazard-LED-Callsign-Image",
-    "jrwrodgers/rh-wled-ctr",
-    "PSi86/RaceLink_RH-plugin"
+    "jrwrodgers/rh-wled-ctr"
   ],
   "Streaming & Overlays": [
     "dutchdronesquad/rh-youtube-chapters",

--- a/categories.json
+++ b/categories.json
@@ -34,7 +34,8 @@
   ],
   "LED Effects": [
     "HazardCreative/RotorHazard-LED-Callsign-Image",
-    "jrwrodgers/rh-wled-ctr"
+    "jrwrodgers/rh-wled-ctr",
+    "PSi86/RaceLink_RH-plugin"
   ],
   "Streaming & Overlays": [
     "dutchdronesquad/rh-youtube-chapters",
@@ -49,6 +50,7 @@
     "Dutch-Drone-Racing/RH-Plugin-EventAction-UDP-Message",
     "HazardCreative/RotorHazard-Idle-Race_Handler",
     "i-am-grub/netpack-installer",
+    "PSi86/RaceLink_RH-plugin",
     "RotorHazard/LapRF-Interface"
   ],
   "Other": [

--- a/plugins.json
+++ b/plugins.json
@@ -30,6 +30,7 @@
   "L1cardo/RH-Pilot-CSV-Importer",
   "L1cardo/RH-Pilot-Local-Importer",
   "MarijnKoesen/rh_race_round_announcer",
+  "PSi86/RaceLink_RH-plugin",
   "RotorHazard/Connector-FPVTrackSide",
   "RotorHazard/LapRF-Interface",
   "RotorHazard/VRxC-ClearView2",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->
## Description
Integrate RotorHazard into the RaceLink System to control WLED RaceLink Nodes, Startblocks and Custom Devices.


## Checklist
<!--
  Put an `x` in the boxes that you have completed. You can
  also fill these out after creating the PR. If you're unsure
  about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I've added the [RHFest action](https://github.com/RotorHazard/rhfest-action) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've created a github release in my repository with [semver](https://semver.org/) versioning.
- [x] I've added all the requested links below.

**Note:** all checks above should be passed before a pull request will be merged.

## Additional information
<!--
  Details are important, and help us processing your PR.
  Please be sure to fill out additional details.
-->
The RaceLink System enables wireless communication on 433MHz or 900MHz leaving 2.4GHz and 5.8GHz open for the pilot signals.

- Link to plugin repository: https://github.com/PSi86/RaceLink_RH-plugin
- Link to current release: https://github.com/PSi86/RaceLink_RH-plugin/releases/tag/v0.1.2-beta
- Link to successful rhfest action: https://github.com/PSi86/RaceLink_RH-plugin/actions/runs/24520427472
