### PR TITLE
Add FAI-like-8-pilots and Best-X-Laps-Cumulative

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -15,9 +15,11 @@
     "vikibaarathi/rh-google-connector"
   ],
   "Heat Generators": [
+    "arnaudmorin/RotorHazard-Generator-FAI-like-8-pilots",
     "Dutch-Drone-Racing/RH-Generator-8-Pilot-DE"
   ],
   "Class Rankings": [
+    "arnaudmorin/RotorHazard-Class-Rank-Best-X-Laps-Cumulative",
     "FiorixF1/RotorHazard-Class-Rank-Brackets",
     "Aaronsss/cumulative-points-per-heat-RH-plugin",
     "HazardCreative/RotorHazard-Class-Rank-Best-X-Laps",

--- a/plugins.json
+++ b/plugins.json
@@ -3,6 +3,8 @@
   "Aaronsss/RH-sensor-monitor",
   "Aaronsss/RH-Settings-Restore",
   "Aaronsss/Rotorhazard-OBS-Websocks-Plugin",
+  "arnaudmorin/RotorHazard-Class-Rank-Best-X-Laps-Cumulative",
+  "arnaudmorin/RotorHazard-Generator-FAI-like-8-pilots",
   "arulrajesh/RH-Pilot-Queue",
   "Christoph-Hofmann/oled_rotorhazard_display",
   "Dutch-Drone-Racing/RH-Dropgate",


### PR DESCRIPTION
Add two new plugins:
- arnaudmorin/RotorHazard-Generator-FAI-like-8-pilots
- arnaudmorin/RotorHazard-Class-Rank-Best-X-Laps-Cumulative

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->
## Description



## Checklist
<!--
  Put an `x` in the boxes that you have completed. You can
  also fill these out after creating the PR. If you're unsure
  about any of them, don't hesitate to ask. We're here to help!
-->

- [X] I've added the [RHFest action](https://github.com/RotorHazard/rhfest-action) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've created a github release in my repository with [semver](https://semver.org/) versioning.
- [X] I've added all the requested links below.

**Note:** all checks above should be passed before a pull request will be merged.

## Additional information
<!--
  Details are important, and help us processing your PR.
  Please be sure to fill out additional details.
-->

- Link to plugin repository:
 - https://github.com/arnaudmorin/RotorHazard-Generator-FAI-like-8-pilots
 - https://github.com/arnaudmorin/RotorHazard-Class-Rank-Best-X-Laps-Cumulative
- Link to current release:
 - https://github.com/arnaudmorin/RotorHazard-Generator-FAI-like-8-pilots/releases/tag/1.0.0
 - https://github.com/arnaudmorin/RotorHazard-Class-Rank-Best-X-Laps-Cumulative/releases/tag/1.0.0
- Link to successful rhfest action:
 - https://github.com/arnaudmorin/RotorHazard-Generator-FAI-like-8-pilots/actions/runs/27322901100
 - https://github.com/arnaudmorin/RotorHazard-Class-Rank-Best-X-Laps-Cumulative/actions/runs/27320509039
