### PR TITLE
Add RotorHazard-Generator-FAI-like-8-pilots

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -15,6 +15,7 @@
     "vikibaarathi/rh-google-connector"
   ],
   "Heat Generators": [
+    "arnaudmorin/RotorHazard-Generator-FAI-like-8-pilots",
     "Dutch-Drone-Racing/RH-Generator-8-Pilot-DE"
   ],
   "Class Rankings": [

--- a/plugins.json
+++ b/plugins.json
@@ -3,6 +3,7 @@
   "Aaronsss/RH-sensor-monitor",
   "Aaronsss/RH-Settings-Restore",
   "Aaronsss/Rotorhazard-OBS-Websocks-Plugin",
+  "arnaudmorin/RotorHazard-Generator-FAI-like-8-pilots",
   "arulrajesh/RH-Pilot-Queue",
   "Christoph-Hofmann/oled_rotorhazard_display",
   "Dutch-Drone-Racing/RH-Dropgate",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->
## Description

Add a new plugin to help genereate 8 pilots like races (like FAI) with both single and double elimination schema.

## Checklist
<!--
  Put an `x` in the boxes that you have completed. You can
  also fill these out after creating the PR. If you're unsure
  about any of them, don't hesitate to ask. We're here to help!
-->

- [X] I've added the [RHFest action](https://github.com/RotorHazard/rhfest-action) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've created a github release in my repository with [semver](https://semver.org/) versioning.
- [X] I've added all the requested links below.

**Note:** all checks above should be passed before a pull request will be merged.

## Additional information
<!--
  Details are important, and help us processing your PR.
  Please be sure to fill out additional details.
-->

- Link to plugin repository: https://github.com/arnaudmorin/RotorHazard-Generator-FAI-like-8-pilots
- Link to current release: https://github.com/arnaudmorin/RotorHazard-Generator-FAI-like-8-pilots/releases/tag/1.0.0
- Link to successful rhfest action: https://github.com/arnaudmorin/RotorHazard-Generator-FAI-like-8-pilots/actions/runs/27322901100
