### PR TITLE
Enhance plugin validation workflow and documentation

### DIFF
--- a/.github/workflows/plugin-checks.yaml
+++ b/.github/workflows/plugin-checks.yaml
@@ -119,6 +119,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: preflight
     if: ${{ needs.preflight.outputs.action == 'add' }}
+    outputs:
+      ref: ${{ steps.validation.outputs.ref }}
     steps:
       - name: ⤵️ Check out code
         uses: actions/checkout@v7.0.0
@@ -130,6 +132,7 @@ jobs:
       - name: 🏗 Install project dependencies
         run: uv sync --no-group dev
       - name: 🚀 Run validation
+        id: validation
         run: uv run python scripts/check_releases.py --repository="${{ needs.preflight.outputs.repository }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -165,13 +168,17 @@ jobs:
   rhfest:
     name: RHFest validation
     runs-on: ubuntu-latest
-    needs: preflight
+    needs: [preflight, releases]
     if: ${{ needs.preflight.outputs.action == 'add' }}
     steps:
-      - name: ⤵️ Clone added plugin repository
-        run: git clone --depth 1 "https://github.com/${{ needs.preflight.outputs.repository }}" .
+      - name: ⤵️ Check out added plugin release
+        uses: actions/checkout@v7.0.0
+        with:
+          repository: ${{ needs.preflight.outputs.repository }}
+          ref: ${{ needs.releases.outputs.ref }}
+          fetch-depth: 1
       - name: 🚀 Run RHFest Validation
-        uses: docker://ghcr.io/rotorhazard/rhfest-action:v3.0.1
+        uses: docker://ghcr.io/rotorhazard/rhfest-action:v3.1.0
 
   # 6) Aggregator: single required status
   checks:

--- a/docs/docs/plugin/include.md
+++ b/docs/docs/plugin/include.md
@@ -56,13 +56,15 @@ Check whether the plugin repository is assigned to a valid category. The list of
 
 We expect at least 1 release to be published in the added repository. More about this can also be found on the [Getting started](index.md#github-releases) page.
 
+The latest stable release is selected for validation. If no stable release exists, the latest pre-release is selected instead. RHFest validates this same release tag, so make sure the repository structure and `manifest.json` are valid in the published release, not only on the default branch.
+
 ### Check Removed
 
 Check whether the plugin repository is on the list of previously removed plugins. If it is, the plugin will not be accepted/included in the community plugins database. The list of removed plugins can be found in the [`removed.json`][removed] file.
 
 ### RHFest validation
 
-Check that the `manifest.json` file and repository structure are valid. More details can be found on the dedicated [RHFest](../rhfest/index.md) page.
+Check that the selected release has a valid `manifest.json` and repository structure. More details can be found on the dedicated [RHFest](../rhfest/index.md) page.
 
 ### Lint [jq]
 

--- a/docs/docs/rhfest/index.md
+++ b/docs/docs/rhfest/index.md
@@ -8,7 +8,7 @@ hide:
 
 # RHFest Action
 
-**RHFest** is a GitHub Action that automatically validates RotorHazard plugins to ensure they follow official structure and formatting standards. It checks for required files, verifies the contents of the `manifest.json`, and confirms that version numbers are formatted correctly.
+**RHFest** is a GitHub Action that automatically validates RotorHazard plugins to ensure they follow official structure and formatting standards. It checks for required files, verifies the contents of the `manifest.json`, confirms that the plugin folder matches the manifest `domain`, and validates version number formatting.
 
 This helps plugin authors maintain consistent quality and catch problems before release. It is also a mandatory part if you want to add a plugin to the database.
 

--- a/scripts/check_releases.py
+++ b/scripts/check_releases.py
@@ -6,6 +6,8 @@ import logging
 import os
 import re
 import sys
+from pathlib import Path
+from typing import Any
 
 from aiogithubapi import GitHubAPI, GitHubException
 from dotenv import load_dotenv
@@ -61,6 +63,26 @@ def is_valid_semver(tag: str) -> bool:
     return bool(SEMVER_REGEX.match(tag))
 
 
+def select_used_ref(releases: list[Any]) -> str:
+    """Select the same release ref used by the metadata generator."""
+    sorted_releases = sorted(
+        releases, key=lambda release: release.created_at, reverse=True
+    )
+    latest_stable = next(
+        (release for release in sorted_releases if not release.prerelease), None
+    )
+    selected_release = latest_stable or sorted_releases[0]
+    return selected_release.tag_name
+
+
+def write_github_output(ref: str) -> None:
+    """Expose the selected release ref to downstream workflow jobs."""
+    github_output = os.getenv("GITHUB_OUTPUT")
+    if github_output:
+        with Path.open(github_output, "a", encoding="utf-8") as output_file:
+            print(f"ref={ref}", file=output_file)
+
+
 async def check_releases(repository: str, token: str) -> None:
     """Check if a GitHub repository has at least one release.
 
@@ -84,18 +106,16 @@ async def check_releases(repository: str, token: str) -> None:
             LOGGER.error(f"No releases found for repository: {repository}")
             sys.exit(1)
 
-        # Sort releases by creation date (latest first)
-        sorted_releases = sorted(releases, key=lambda r: r.created_at, reverse=True)
-        latest_release = sorted_releases[0]
-        tag = getattr(latest_release, "tag_name", "")
-        LOGGER.info(f"🔍 Latest release tag: {tag}")
+        tag = select_used_ref(releases)
+        LOGGER.info(f"🔍 Selected release tag: {tag}")
 
-        # Check if the latest release tag follows SemVer
+        # Check if the selected release tag follows SemVer
         if not is_valid_semver(tag.removeprefix("v")):
-            LOGGER.error(f"The latest release tag '{tag}' does not follow SemVer.")
+            LOGGER.error(f"The selected release tag '{tag}' does not follow SemVer.")
             sys.exit(1)
         else:
-            LOGGER.info("✅ The latest release tag follows SemVer.")
+            LOGGER.info("✅ The selected release tag follows SemVer.")
+            write_github_output(tag)
 
 
 if __name__ == "__main__":

--- a/tests/test_check_releases.py
+++ b/tests/test_check_releases.py
@@ -1,0 +1,54 @@
+"""Tests for scripts/check_releases.py."""
+
+import importlib.util
+from datetime import UTC, datetime
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+def load_script_module() -> ModuleType:
+    """Load the check_releases script as a module for testing."""
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "check_releases.py"
+    spec = importlib.util.spec_from_file_location("check_releases_module", script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def release(tag: str, *, prerelease: bool, day: int) -> SimpleNamespace:
+    """Create a minimal GitHub release object."""
+    return SimpleNamespace(
+        tag_name=tag,
+        prerelease=prerelease,
+        created_at=datetime(2026, 1, day, tzinfo=UTC),
+    )
+
+
+def test_select_used_ref_prefers_stable_release() -> None:
+    """The latest stable release wins over a newer prerelease."""
+    module = load_script_module()
+
+    selected_ref = module.select_used_ref(
+        [
+            release("v2.0.0-beta.1", prerelease=True, day=3),
+            release("v1.1.0", prerelease=False, day=2),
+            release("v1.0.0", prerelease=False, day=1),
+        ]
+    )
+
+    assert selected_ref == "v1.1.0"
+
+
+def test_select_used_ref_falls_back_to_latest_prerelease() -> None:
+    """The newest prerelease is used when no stable release exists."""
+    module = load_script_module()
+
+    selected_ref = module.select_used_ref(
+        [
+            release("v1.0.0-beta.1", prerelease=True, day=1),
+            release("v1.0.0-beta.2", prerelease=True, day=2),
+        ]
+    )
+
+    assert selected_ref == "v1.0.0-beta.2"


### PR DESCRIPTION
## Summary

Ensure RHFest validates the same plugin release that is used by the metadata generator.

## Changes

- Select the latest stable release for validation
- Fall back to the latest prerelease when no stable release exists
- Expose the selected release tag as a workflow output
- Check out the selected release before running RHFest
- Add tests for stable and prerelease selection
- Document which release is selected and validated
- Document that the plugin folder must match the manifest `domain`

## Motivation

Previously, the community plugin checks ran RHFest against the repository's default branch, while metadata generation usually reads the latest stable release.

This allowed the following situation:

- The default branch passed RHFest
- The published release contained an invalid structure or manifest
- Metadata generation failed later

The release validation and RHFest jobs now use the same release-selection strategy as metadata generation.

## Release selection

The validation ref is selected in this order:

1. Latest stable release
2. Latest prerelease, when no stable release exists

RHFest checks out and validates that exact release tag.
