### PR TITLE
Validate selected plugin release with RHFest

### DIFF
--- a/.github/workflows/plugin-checks.yaml
+++ b/.github/workflows/plugin-checks.yaml
@@ -47,6 +47,7 @@ jobs:
     outputs:
       repository: ${{ steps.out.outputs.repository }}
       action: ${{ steps.out.outputs.action }}
+      ref: ${{ steps.out.outputs.ref }}
     steps:
       # If relevant: do the full preflight
       - name: ⤵️ Check out code (PR merge commit)
@@ -81,6 +82,7 @@ jobs:
         run: |
           echo "repository=${{ steps.check.outputs.repository }}" >> "$GITHUB_OUTPUT"
           echo "action=${{ steps.check.outputs.action }}" >> "$GITHUB_OUTPUT"
+          echo "ref=${{ steps.check.outputs.ref }}" >> "$GITHUB_OUTPUT"
 
   # 2) Categories: run only when relevant (action or repository set)
   categories:
@@ -119,8 +121,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: preflight
     if: ${{ needs.preflight.outputs.action == 'add' }}
-    outputs:
-      ref: ${{ steps.validation.outputs.ref }}
     steps:
       - name: ⤵️ Check out code
         uses: actions/checkout@v7.0.0
@@ -132,7 +132,6 @@ jobs:
       - name: 🏗 Install project dependencies
         run: uv sync --no-group dev
       - name: 🚀 Run validation
-        id: validation
         run: uv run python scripts/check_releases.py --repository="${{ needs.preflight.outputs.repository }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -168,14 +167,14 @@ jobs:
   rhfest:
     name: RHFest validation
     runs-on: ubuntu-latest
-    needs: [preflight, releases]
+    needs: preflight
     if: ${{ needs.preflight.outputs.action == 'add' }}
     steps:
       - name: ⤵️ Check out added plugin release
         uses: actions/checkout@v7.0.0
         with:
           repository: ${{ needs.preflight.outputs.repository }}
-          ref: ${{ needs.releases.outputs.ref }}
+          ref: ${{ needs.preflight.outputs.ref }}
           fetch-depth: 1
       - name: 🚀 Run RHFest Validation
         uses: docker://ghcr.io/rotorhazard/rhfest-action:v3.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ show_missing = true
 [tool.pytest.ini_options]
 addopts = "--cov"
 asyncio_mode = "auto"
-pythonpath = "metadata"
+pythonpath = ["metadata", "scripts"]
 filterwarnings = [
   "ignore:'asyncio\\.iscoroutinefunction' is deprecated and slated for removal in Python 3\\.16; use inspect\\.iscoroutinefunction\\(\\) instead:DeprecationWarning:backoff\\._decorator",
   "ignore:'asyncio\\.iscoroutinefunction' is deprecated and slated for removal in Python 3\\.16; use inspect\\.iscoroutinefunction\\(\\) instead:DeprecationWarning:backoff\\._async",

--- a/scripts/check_preflight.py
+++ b/scripts/check_preflight.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from aiogithubapi import GitHubAPI, GitHubException
 from dotenv import load_dotenv
+from release_selection import select_used_ref
 
 load_dotenv()
 
@@ -80,13 +81,33 @@ async def get_canonical_repo_name(repository: str, token: str) -> str:
             return canonical_name
 
 
-def write_github_output(repository: str, action: str) -> None:
+def write_github_output(repository: str, action: str, ref: str = "") -> None:
     """Write outputs to GITHUB_OUTPUT for use in workflow."""
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:
         with Path.open(github_output, "a", encoding="utf-8") as ghf:
             print(f"repository={repository}", file=ghf)
             print(f"action={action}", file=ghf)
+            print(f"ref={ref}", file=ghf)
+
+
+async def get_used_ref(repository: str, token: str) -> str:
+    """Resolve the release ref that downstream checks should use."""
+    async with GitHubAPI(token) as github:
+        try:
+            response = await github.repos.releases.list(repository)
+        except GitHubException:
+            LOGGER.exception(f"Failed to fetch releases for '{repository}'.")
+            sys.exit(1)
+
+    releases = response.data
+    if not releases:
+        LOGGER.error(f"No releases found for repository: {repository}")
+        sys.exit(1)
+
+    ref = select_used_ref(releases)
+    LOGGER.info(f"✅ Selected release ref: {ref}")
+    return ref
 
 
 async def validate_repo_name(repo: str) -> None:
@@ -168,7 +189,12 @@ async def async_main() -> None:
         repo = added[0]
         LOGGER.info(f"✅ One repository added: {repo}")
         await validate_repo_name(repo)
-        write_github_output(repo, "add")
+        token = os.getenv("GITHUB_TOKEN")
+        if not token:
+            LOGGER.error("No GitHub token provided.")
+            sys.exit(1)
+        ref = await get_used_ref(repo, token)
+        write_github_output(repo, "add", ref)
     elif len(added) == 0 and len(removed) == 1:
         repo = removed[0]
         LOGGER.info(f"✅ One repository removed: {repo}")

--- a/scripts/check_releases.py
+++ b/scripts/check_releases.py
@@ -6,11 +6,10 @@ import logging
 import os
 import re
 import sys
-from pathlib import Path
-from typing import Any
 
 from aiogithubapi import GitHubAPI, GitHubException
 from dotenv import load_dotenv
+from release_selection import select_used_ref
 
 load_dotenv()
 
@@ -63,26 +62,6 @@ def is_valid_semver(tag: str) -> bool:
     return bool(SEMVER_REGEX.match(tag))
 
 
-def select_used_ref(releases: list[Any]) -> str:
-    """Select the same release ref used by the metadata generator."""
-    sorted_releases = sorted(
-        releases, key=lambda release: release.created_at, reverse=True
-    )
-    latest_stable = next(
-        (release for release in sorted_releases if not release.prerelease), None
-    )
-    selected_release = latest_stable or sorted_releases[0]
-    return selected_release.tag_name
-
-
-def write_github_output(ref: str) -> None:
-    """Expose the selected release ref to downstream workflow jobs."""
-    github_output = os.getenv("GITHUB_OUTPUT")
-    if github_output:
-        with Path.open(github_output, "a", encoding="utf-8") as output_file:
-            print(f"ref={ref}", file=output_file)
-
-
 async def check_releases(repository: str, token: str) -> None:
     """Check if a GitHub repository has at least one release.
 
@@ -115,7 +94,6 @@ async def check_releases(repository: str, token: str) -> None:
             sys.exit(1)
         else:
             LOGGER.info("✅ The selected release tag follows SemVer.")
-            write_github_output(tag)
 
 
 if __name__ == "__main__":

--- a/scripts/release_selection.py
+++ b/scripts/release_selection.py
@@ -1,0 +1,15 @@
+"""Shared release selection helpers."""
+
+from typing import Any
+
+
+def select_used_ref(releases: list[Any]) -> str:
+    """Select the latest stable release, or the latest prerelease as fallback."""
+    sorted_releases = sorted(
+        releases, key=lambda release: release.created_at, reverse=True
+    )
+    latest_stable = next(
+        (release for release in sorted_releases if not release.prerelease), None
+    )
+    selected_release = latest_stable or sorted_releases[0]
+    return selected_release.tag_name

--- a/tests/test_check_preflight.py
+++ b/tests/test_check_preflight.py
@@ -22,6 +22,45 @@ def load_script_module() -> ModuleType:
 
 
 @pytest.mark.asyncio
+async def test_async_main_outputs_release_ref_for_added_repository(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An added repository should expose its selected release ref."""
+    module = load_script_module()
+    repository = "owner/repository"
+    outputs = {}
+
+    (tmp_path / "plugins_old.json").write_text("[]", encoding="utf-8")
+    (tmp_path / "plugins.json").write_text(json.dumps([repository]), encoding="utf-8")
+
+    async def fake_validate_repo_name(repo: str) -> None:
+        assert repo == repository
+
+    async def fake_get_used_ref(repo: str, token: str) -> str:
+        assert repo == repository
+        assert token == TEST_GITHUB_TOKEN
+        return "v1.2.3"
+
+    def fake_write_github_output(repository: str, action: str, ref: str = "") -> None:
+        outputs.update(repository=repository, action=action, ref=ref)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("GITHUB_TOKEN", TEST_GITHUB_TOKEN)
+    monkeypatch.setattr(module, "validate_repo_name", fake_validate_repo_name)
+    monkeypatch.setattr(module, "get_used_ref", fake_get_used_ref)
+    monkeypatch.setattr(module, "write_github_output", fake_write_github_output)
+
+    await module.async_main()
+
+    assert outputs == {
+        "repository": repository,
+        "action": "add",
+        "ref": "v1.2.3",
+    }
+
+
+@pytest.mark.asyncio
 async def test_async_main_accepts_repository_rename(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Resolve the selected plugin release ref during preflight so all four plugin validation jobs can run in parallel again.

## Changes

- Resolve the latest stable release during preflight
- Fall back to the latest prerelease when no stable release exists
- Expose the selected release ref as a preflight output
- Make RHFest consume the preflight ref directly
- Remove the dependency between RHFest and release validation
- Extract release selection into a shared helper
- Add test coverage for the preflight ref output
- Add `scripts` to the pytest import path

## Workflow

The validation jobs can now start in parallel after preflight:

```text
preflight
   ├── categories
   ├── releases
   ├── removed
   └── rhfest
```

Previously, RHFest depended on the release validation job to obtain the selected ref:

```text
preflight → releases → rhfest
```

Preflight now resolves that ref itself, allowing RHFest and release validation to run independently.