### PR TITLE
Add izicubed/RotorHazard-Sound-FX

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -53,6 +53,7 @@
     "HazardCreative/RotorHazard-Idle-Race_Handler",
     "i-am-grub/netpack-installer",
     "izicubed/RotorHazard-Sensor-Top-Bar",
+    "izicubed/RotorHazard-Sound-FX",
     "PSi86/RaceLink_RH_Plugin",
     "RotorHazard/LapRF-Interface"
   ],

--- a/plugins.json
+++ b/plugins.json
@@ -27,6 +27,7 @@
   "i-am-grub/vrxc_elrs",
   "izicubed/RotorHazard-Claude-Marshal",
   "izicubed/RotorHazard-Sensor-Top-Bar",
+  "izicubed/RotorHazard-Sound-FX",
   "jrwrodgers/event_plots",
   "jrwrodgers/pilot_palette",
   "jrwrodgers/rh-wled-ctr",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->
## Description

Adds **Sound FX** to the catalog (Utilities).

Plays custom MP3/WAV/OGG sounds on race events (staging, start, finish, stop, winner, holeshot, laps, pilot finished, race saved and more) and a personal per-pilot sound (e.g. a name callout) on individually selectable triggers. Speaks composed phrases: pilot + lap number on every pass, next-group announcements with pilot and channel callouts, countdowns to a scheduled start and to the end of a timed race. Sounds are uploaded from the Settings page and play in every connected browser; a standalone `/sound_fx/player` page turns any phone or tablet into a dedicated speaker, and playback on the server's own audio output is optional. No extra Python dependencies.

## Checklist
<!--
  Put an `x` in the boxes that you have completed. You can
  also fill these out after creating the PR. If you're unsure
  about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I've added the [RHFest action](https://github.com/RotorHazard/rhfest-action) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've created a github release in my repository with [semver](https://semver.org/) versioning.
- [x] I've added all the requested links below.

**Note:** all checks above should be passed before a pull request will be merged.

## Additional information
<!--
  Details are important, and help us processing your PR.
  Please be sure to fill out additional details.
-->

- Link to plugin repository: https://github.com/izicubed/RotorHazard-Sound-FX
- Link to current release: https://github.com/izicubed/RotorHazard-Sound-FX/releases/tag/v1.1.1
- Link to successful rhfest action: https://github.com/izicubed/RotorHazard-Sound-FX/actions/runs/30184447206
