### PR TITLE
Rename izicubed/RotorHazard-Claude-Marshal to RotorHazard-Auto-Marshalling

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -27,7 +27,7 @@
     "HazardCreative/RotorHazard-Class-Rank-Best-Percentage"
   ],
   "Results Analysis": [
-    "izicubed/RotorHazard-Claude-Marshal",
+    "izicubed/RotorHazard-Auto-Marshalling",
     "jrwrodgers/event_plots"
   ],
   "OSD & VRx Control": [

--- a/plugins.json
+++ b/plugins.json
@@ -25,7 +25,7 @@
   "i-am-grub/multigp_toolkit",
   "i-am-grub/netpack-installer",
   "i-am-grub/vrxc_elrs",
-  "izicubed/RotorHazard-Claude-Marshal",
+  "izicubed/RotorHazard-Auto-Marshalling",
   "izicubed/RotorHazard-Sensor-Top-Bar",
   "jrwrodgers/event_plots",
   "jrwrodgers/pilot_palette",


### PR DESCRIPTION
The plugin formerly listed as **Claude Auto Marshalling** (`izicubed/RotorHazard-Claude-Marshal`, added in #413) has been renamed to **Auto Marshalling** and its repository moved to `izicubed/RotorHazard-Auto-Marshalling` (GitHub redirects the old URL).

As of v2.0.0 the plugin is fully local — the Claude API layer was removed (split out into a separate opt-in add-on repo), so the plugin now works with no API key, no internet and no Python dependencies. Same category (Results Analysis).

This PR updates `plugins.json` and `categories.json` to the new repository name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)