### PR TITLE
Add izicubed/RotorHazard-ELRS-Web-Backpack

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -32,6 +32,7 @@
   ],
   "OSD & VRx Control": [
     "i-am-grub/vrxc_elrs",
+    "izicubed/RotorHazard-ELRS-Web-Backpack",
     "RotorHazard/VRxC-ClearView2",
     "RotorHazard/VRxC-Fusion"
   ],

--- a/plugins.json
+++ b/plugins.json
@@ -26,6 +26,7 @@
   "i-am-grub/netpack-installer",
   "i-am-grub/vrxc_elrs",
   "izicubed/RotorHazard-Auto-Marshalling",
+  "izicubed/RotorHazard-ELRS-Web-Backpack",
   "izicubed/RotorHazard-Sensor-Top-Bar",
   "jrwrodgers/event_plots",
   "jrwrodgers/pilot_palette",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->
## Description

Adds **ELRS Web Backpack** to the catalog (OSD & VRx Control).

Pilot OSD over the ExpressLRS Backpack, transmitted from the computer that has RotorHazard open in a browser instead of from the timer: the server builds the MSP packets (same protocol and OSD layout as `i-am-grub/vrxc_elrs`) and pushes them over socket.io to the browser, which writes them to the ESP on its own USB port through the Web Serial API. Useful when the timer sits at the gate and the pilots sit too far away for its backpack to reach. Also supports a backpack on the timer itself alongside the browser one, per-event notification toggles, independent lap/position/lap-result OSD lines, race start/stop from the race director's transmitter, and Cyrillic callsign transliteration. Derived from [VRxC_ELRS](https://github.com/i-am-grub/VRxC_ELRS) (GPL-3.0), credited in the README and manifest.

## Checklist
<!--
  Put an `x` in the boxes that you have completed. You can
  also fill these out after creating the PR. If you're unsure
  about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I've added the [RHFest action](https://github.com/RotorHazard/rhfest-action) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've created a github release in my repository with [semver](https://semver.org/) versioning.
- [x] I've added all the requested links below.

**Note:** all checks above should be passed before a pull request will be merged.

## Additional information
<!--
  Details are important, and help us processing your PR.
  Please be sure to fill out additional details.
-->

- Link to plugin repository: https://github.com/izicubed/RotorHazard-ELRS-Web-Backpack
- Link to current release: https://github.com/izicubed/RotorHazard-ELRS-Web-Backpack/releases/tag/v1.0.1
- Link to successful rhfest action: https://github.com/izicubed/RotorHazard-ELRS-Web-Backpack/actions/runs/30208890998
