### PR TITLE
Add DavidCalderon1/RH-Points-Finish-Required

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -24,7 +24,8 @@
     "Aaronsss/cumulative-points-per-heat-RH-plugin",
     "HazardCreative/RotorHazard-Class-Rank-Best-X-Laps",
     "HazardCreative/RotorHazard-Class-Rank-Heat-Points",
-    "HazardCreative/RotorHazard-Class-Rank-Best-Percentage"
+    "HazardCreative/RotorHazard-Class-Rank-Best-Percentage",
+    "DavidCalderon1/RH-Points-Finish-Required"
   ],
   "Results Analysis": [
     "izicubed/RotorHazard-Auto-Marshalling",

--- a/plugins.json
+++ b/plugins.json
@@ -7,6 +7,7 @@
   "arnaudmorin/RotorHazard-Generator-FAI-like-8-pilots",
   "arulrajesh/RH-Pilot-Queue",
   "Christoph-Hofmann/oled_rotorhazard_display",
+  "DavidCalderon1/RH-Points-Finish-Required",
   "Dutch-Drone-Racing/RH-Dropgate",
   "Dutch-Drone-Racing/RH-Generator-8-Pilot-DE",
   "Dutch-Drone-Racing/RH-Plugin-EventAction-UDP-Message",


### PR DESCRIPTION
Race points method that requires a minimum number of completed laps before a pilot is eligible for position-based points, so a heat with more than one non-finisher no longer hands out finishing-order points to someone who didn't complete the race.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->
## Description



## Checklist
<!--
  Put an `x` in the boxes that you have completed. You can
  also fill these out after creating the PR. If you're unsure
  about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I've added the [RHFest action](https://github.com/RotorHazard/rhfest-action) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've created a github release in my repository with [semver](https://semver.org/) versioning.
- [ ] I've added all the requested links below.

**Note:** all checks above should be passed before a pull request will be merged.

## Additional information
<!--
  Details are important, and help us processing your PR.
  Please be sure to fill out additional details.
-->

- Link to plugin repository:
- Link to current release:
- Link to successful rhfest action:
