### PR TITLE
Add DavidCalderon1/RH-Generator-Minimize-Repeats

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -16,7 +16,8 @@
   ],
   "Heat Generators": [
     "arnaudmorin/RotorHazard-Generator-FAI-like-8-pilots",
-    "Dutch-Drone-Racing/RH-Generator-8-Pilot-DE"
+    "Dutch-Drone-Racing/RH-Generator-8-Pilot-DE",
+    "DavidCalderon1/RH-Generator-Minimize-Repeats"
   ],
   "Class Rankings": [
     "arnaudmorin/RotorHazard-Class-Rank-Best-X-Laps-Cumulative",

--- a/plugins.json
+++ b/plugins.json
@@ -7,6 +7,7 @@
   "arnaudmorin/RotorHazard-Generator-FAI-like-8-pilots",
   "arulrajesh/RH-Pilot-Queue",
   "Christoph-Hofmann/oled_rotorhazard_display",
+  "DavidCalderon1/RH-Generator-Minimize-Repeats",
   "Dutch-Drone-Racing/RH-Dropgate",
   "Dutch-Drone-Racing/RH-Generator-8-Pilot-DE",
   "Dutch-Drone-Racing/RH-Plugin-EventAction-UDP-Message",


### PR DESCRIPTION
Heat generator that works like Balanced Random Fill, but looks at the heats already saved in the destination class and searches for the pilot grouping that minimizes repeated pairings against that history, instead of a single blind shuffle each time it's run.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->
## Description



## Checklist
<!--
  Put an `x` in the boxes that you have completed. You can
  also fill these out after creating the PR. If you're unsure
  about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I've added the [RHFest action](https://github.com/RotorHazard/rhfest-action) to my repository.
- [ ] The actions are passing without any disabled checks in my repository.
- [ ] I've created a github release in my repository with [semver](https://semver.org/) versioning.
- [ ] I've added all the requested links below.

**Note:** all checks above should be passed before a pull request will be merged.

## Additional information
<!--
  Details are important, and help us processing your PR.
  Please be sure to fill out additional details.
-->

- Link to plugin repository:
- Link to current release:
- Link to successful rhfest action:
